### PR TITLE
Obsolete default exports

### DIFF
--- a/src/IImporter.ts
+++ b/src/IImporter.ts
@@ -1,7 +1,10 @@
-import ISourceConfig from './config/ISourceConfig';
+import { ISourceConfig } from './config/ISourceConfig';
 
-// todo obsolete default export
-export default interface IImporter {
+export interface IImporter {
     // todo obsolete and rename to loverCase
     GetAllItems<T>(people: ISourceConfig): T[];
 }
+
+/** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IImporter }`). */
+// tslint:disable-next-line:no-empty-interface
+export default interface IImporterLegacy extends IImporter {};

--- a/src/Importer.ts
+++ b/src/Importer.ts
@@ -1,11 +1,10 @@
 import { Workbook } from 'exceljs';
 import { IMPORT_TYPE_DEFAULT, ImportType } from './config/ImportType';
-import ISourceConfig from './config/ISourceConfig';
-import IImporter from './IImporter';
+import { ISourceConfig } from './config/ISourceConfig';
+import { IImporter } from './IImporter';
 import { getStrategyByType } from './strategies';
 
-// todo obsolete default export
-export default class Importer implements IImporter {
+export class Importer implements IImporter {
     constructor(private wb: Workbook) {}
 
     // todo obsolete and rename to loverCase
@@ -17,3 +16,7 @@ export default class Importer implements IImporter {
         return getStrategyByType(type)(cfg, ws);
     }
 }
+
+/** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ Importer }`). */
+// tslint:disable-next-line:no-empty-interface max-classes-per-file
+export default class ImporterLegacy extends Importer {};

--- a/src/ImporterFactory.ts
+++ b/src/ImporterFactory.ts
@@ -1,9 +1,8 @@
 import { Workbook } from 'exceljs';
-import IImporter from './IImporter';
-import Importer from './Importer';
+import { IImporter } from './IImporter';
+import { Importer } from './Importer';
 
-// todo obsolete default export
-export default class ImporterFactory {
+export class ImporterFactory {
     // todo obsolete and rename to loverCase
     public async From(path: string): Promise<IImporter> {
         const wb = new Workbook();
@@ -12,3 +11,8 @@ export default class ImporterFactory {
         return new Importer(wb);
     }
 }
+
+/** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ ImporterFactory }`). */
+// tslint:disable-next-line:no-empty-interface max-classes-per-file
+export default class ImporterFactoryLegacy extends ImporterFactory {};
+

--- a/src/config/IColumnConfig.ts
+++ b/src/config/IColumnConfig.ts
@@ -1,6 +1,9 @@
-// todo obsolete default export
-export default interface IColumnConfig {
+export interface IColumnConfig {
     index: number;
     key: string;
     mapper?: (id: string) => any;
 }
+
+/** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IColumnConfig }`). */
+// tslint:disable-next-line:no-empty-interface
+export default interface IColumnConfigLegacy extends IColumnConfig {};

--- a/src/config/IFieldConfig.ts
+++ b/src/config/IFieldConfig.ts
@@ -1,7 +1,10 @@
-// todo obsolete default export
-export default interface IFieldConfig {
+export interface IFieldConfig {
     row: number;
     col: number | string;
     key: string;
     mapper?: (id: string) => any;
 }
+
+/** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IFieldConfig }`). */
+// tslint:disable-next-line:no-empty-interface
+export default interface IFieldConfigLegacy extends IFieldConfig {};

--- a/src/config/IListSourceConfig.ts
+++ b/src/config/IListSourceConfig.ts
@@ -1,8 +1,11 @@
-import IColumnConfig from './IColumnConfig';
-import ISourceConfig from './ISourceConfig';
+import { IColumnConfig } from './IColumnConfig';
+import { ISourceConfig } from './ISourceConfig';
 
-// todo obsolete default export
-export default interface IListSourceConfig extends ISourceConfig {
+export interface IListSourceConfig extends ISourceConfig {
     columns: IColumnConfig[];
     rowOffset: number;
 }
+
+/** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IListSourceConfig }`). */
+// tslint:disable-next-line:no-empty-interface
+export default interface IListSourceConfigLegacy extends IListSourceConfig {};

--- a/src/config/IObjectSourceConfig.ts
+++ b/src/config/IObjectSourceConfig.ts
@@ -1,7 +1,10 @@
-import IFieldConfig from './IFieldConfig';
-import ISourceConfig from './ISourceConfig';
+import { IFieldConfig } from './IFieldConfig';
+import { ISourceConfig } from './ISourceConfig';
 
-// todo obsolete default export
-export default interface IObjectSourceConfig extends ISourceConfig {
+export interface IObjectSourceConfig extends ISourceConfig {
     fields: IFieldConfig[];
 }
+
+/** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IObjectSourceConfig }`). */
+// tslint:disable-next-line:no-empty-interface
+export default interface IObjectSourceConfigLegacy extends IObjectSourceConfig {};

--- a/src/config/ISourceConfig.ts
+++ b/src/config/ISourceConfig.ts
@@ -1,6 +1,10 @@
 import { ImportType } from './ImportType';
 
-export default interface ISourceConfig {
+export interface ISourceConfig {
     type?: ImportType | string;
     worksheet: string;
 }
+
+/** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ ISourceConfig }`). */
+// tslint:disable-next-line:no-empty-interface
+export default interface ISourceConfigLegacy extends ISourceConfig {};

--- a/src/strategies/ImportStrategy.ts
+++ b/src/strategies/ImportStrategy.ts
@@ -1,4 +1,4 @@
 import { Worksheet } from 'exceljs';
-import ISourceConfig from '../config/ISourceConfig';
+import { ISourceConfig } from '../config/ISourceConfig';
 
 export type ImportStrategy = <T>(cfg: ISourceConfig, ws: Worksheet) => T[];

--- a/src/strategies/invalidTypeStrategy.ts
+++ b/src/strategies/invalidTypeStrategy.ts
@@ -1,6 +1,6 @@
 import { Worksheet } from 'exceljs';
 import { IMPORT_TYPE_DEFAULT, ImportType } from '../config/ImportType';
-import ISourceConfig from '../config/ISourceConfig';
+import { ISourceConfig } from '../config/ISourceConfig';
 import { ImportStrategy } from './ImportStrategy';
 import { listVerticalStrategy } from './listVerticalStrategy';
 

--- a/src/strategies/listVerticalStrategy.ts
+++ b/src/strategies/listVerticalStrategy.ts
@@ -1,6 +1,6 @@
 import { Worksheet } from 'exceljs';
-import IListSourceConfig from '../config/IListSourceConfig';
-import ISourceConfig from '../config/ISourceConfig';
+import { IListSourceConfig } from '../config/IListSourceConfig';
+import { ISourceConfig } from '../config/ISourceConfig';
 import { MAPPER_DEFAULT } from '../mappers';
 import { ImportStrategy } from './ImportStrategy';
 

--- a/src/strategies/singleObjectStrategy.ts
+++ b/src/strategies/singleObjectStrategy.ts
@@ -1,6 +1,6 @@
 import { Worksheet } from 'exceljs';
-import IObjectSourceConfig from '../config/IObjectSourceConfig';
-import ISourceConfig from '../config/ISourceConfig';
+import { IObjectSourceConfig } from '../config/IObjectSourceConfig';
+import { ISourceConfig } from '../config/ISourceConfig';
 import { MAPPER_DEFAULT } from '../mappers';
 import { ImportStrategy } from './ImportStrategy';
 


### PR DESCRIPTION
Non default export is much more convenient for maintaining, however I can't change it at once - this probably breaks backward compatibility for some package users. As I don't know how their uses xlsx-import, so in care of all, I have plan to:

1. Deprecate "default" export
2. Wait until January 2020 
3. Remove "default" export
4. Publish major lib version

[**❤️ Sponsor this PR**](https://github.com/sponsors/Siemienik) 