### PR TITLE
[Refactoring] Rename variable

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-#        node-version: [8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x] # version 8 and 9 isn't supported in ExcelJS as default - may I resolve it furter (or ignore)
+#        node-version: [8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x] # version 8 and 9 isn't supported in ExcelJS as default - may I resolve it further (or ignore)
         node-version: [10.x, 11.x, 12.x, 13.x, 14.x]
     steps:
     - uses: actions/checkout@v1
@@ -23,7 +23,7 @@ jobs:
         npm run lint
         npm run build
         npm run test
-        npm run coverageRaport
+        npm run coverageReport
         bash <(curl -s https://codecov.io/bash)
       env:
         CI: true

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ npm i xlsx-import --save
                 {index: 2, key: 'Title'}, // column `B`
                 {index: 5, key: 'Author'}, // column `E`
             ],
-            rowOffset: 1, //offset header row
+            rowOffset: 1, // offset header row
         },
         owner: {
             worksheet: 'About list owner',
             type: 'object',
-            fields:[
-                {row: 2, col:1, key:'FirstName'}, // `A2`
-                {row: 2, col:2, key:'SecondName'}, // `B2`
-                {row: 3, col:1, key:'Age', mapper:Number.parseInt}, // `A3`
+            fields: [
+                {row: 2, col: 1, key: 'FirstName'}, // `A2`
+                {row: 2, col: 2, key: 'SecondName'}, // `B2`
+                {row: 3, col: 1, key: 'Age', mapper: Number.parseInt}, // `A3`
             ]
         },
     };
@@ -65,14 +65,14 @@ interface Person {
 
     //...
 
-    const importer = await  factory.from(filePath);
-    const books = importer.getAllItems<Book>(config.books); //it returns `Book[]`
+    const importer = await factory.from(filePath);
+    const books = importer.getAllItems<Book>(config.books); // it returns `Book[]`
     const author = importer.getAllItems<Person>(config.owner);
 
 ```
 # Samples
 
-Sample integration with `xlsx-import` are placed in [./samples](./samples) directory, Currently available:
+Sample integration with `xlsx-import` are placed in [./samples](./samples) directory. Currently available:
 
 * [NodeJS sample](./samples/nodejs/README.md) of **importing an invoice** - it is pure JS example which runs on nodejs.
 
@@ -109,4 +109,4 @@ This is `type` related configuration, for more information please study examples
 --|---|---|---|----|---|---
 ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅
 
-Node v8 and v9 compatibly was drop after upgrade `ExcelJS` to version 4+ and it is able to turn on by downgrading `xlsx-import` to version 2.2.1 or if needed really impotant by requesting me directly.
+Node v8 and v9 compatibly was drop after upgrade `ExcelJS` to version 4+ and it is able to turn on by downgrading `xlsx-import` to version 2.2.1 or if needed really important by requesting me directly.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "tslint -p tsconfig.json",
     "lint:fix": "tslint -p tsconfig.json --fix",
     "test": "mocha -r ts-node/register tests/**/*.test.ts tests/**/**/*.test.ts",
-    "coverageRaport": "nyc -r lcov -r=text -r=text-summary  -r=json -e .ts -x \"*.test.ts\" mocha -r ts-node/register tests/**/*.test.ts tests/**/**/*.test.ts && nyc report && cp coverage/coverage-final.json coverage/coverage.json",
+    "coverageReport": "nyc -r lcov -r=text -r=text-summary  -r=json -e .ts -x \"*.test.ts\" mocha -r ts-node/register tests/**/*.test.ts tests/**/**/*.test.ts && nyc report && cp coverage/coverage-final.json coverage/coverage.json",
     "prepublishOnly": "npm test && npm run lint && npm run build",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src",

--- a/src/IImporter.ts
+++ b/src/IImporter.ts
@@ -1,14 +1,14 @@
 import { ISourceConfig } from './config/ISourceConfig';
 
 export interface IImporter {
-    getAllItems<T>(people: ISourceConfig): T[];
+    getAllItems<T>(config: ISourceConfig): T[];
 }
 
 /** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IImporter }`). */
 // tslint:disable-next-line:no-empty-interface
 export default interface IImporterLegacy {
     /** @deprecated Refactoring performed, please to use `import { IImporter }` and rename to camelCase version `getAllItems`. */
-    GetAllItems<T>(people: ISourceConfig): T[];
+    GetAllItems<T>(config: ISourceConfig): T[];
 }
 
 /** @deprecated Default exports will be removed in January 2021. Please to use brackets (`{ IImporter }`). */

--- a/src/Importer.ts
+++ b/src/Importer.ts
@@ -8,12 +8,12 @@ import { getStrategyByType } from './strategies';
 export class Importer implements IImporter {
     constructor(private wb: Workbook) {}
 
-    public getAllItems<T>(cfg: ISourceConfig): T[] {
-        const { worksheet } = cfg;
-        const type = (cfg.type as ImportType) || IMPORT_TYPE_DEFAULT;
+    public getAllItems<T>(config: ISourceConfig): T[] {
+        const { worksheet } = config;
+        const type = (config.type as ImportType) || IMPORT_TYPE_DEFAULT;
         const ws = this.wb.getWorksheet(worksheet);
 
-        return getStrategyByType(type)(cfg, ws);
+        return getStrategyByType(type)(config, ws);
     }
 }
 
@@ -21,7 +21,7 @@ export class Importer implements IImporter {
 // tslint:disable-next-line:no-empty-interface max-classes-per-file
 export default class ImporterLegacy extends Importer implements IImporterLegacy {
     /** @deprecated Refactoring performed, please to use `import { Importer }` and rename to camelCase version `getAllItems`. */
-    public GetAllItems<T>(cfg: ISourceConfig): T[] {
-        return this.getAllItems<T>(cfg);
+    public GetAllItems<T>(config: ISourceConfig): T[] {
+        return this.getAllItems<T>(config);
     }
 }


### PR DESCRIPTION
# Description

Closes #30 

I also made a couple of quick fixes

The one that worth to be mentioned is that npm script coverageR**a**port was renamed to coverageR**e**port

If you think that some of the quick fixes was unnecessary I could remove them