### PR TITLE
Test markdown before merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install
       run: npm ci
+    - name: lint markdown
+      run: markdownlint **/*.md
     - name: Check lint
       run: npm run lint
     - name: Check build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: npm install
       run: npm ci
     - name: lint markdown
-      run: markdownlint **/*.md
+      run: node_modules/.bin/markdownlint **/*.md
     - name: Check lint
       run: npm run lint
     - name: Check build

--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ const result = wordsInSentencesMapper(input);
 Node v8 and v9 compatibly was drop after upgrade `ExcelJS` to version 4+ and it is able to turn on by downgrading `xlsx-import` to version 2.2.1 or if needed really important by requesting me directly.
 
 ## Supported browsers
-
 Chrome, Firefox. [_proved here_](https://github.com/Siemienik/xlsx-import/pull/57)
 
 ## See also

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ const result = wordsInSentencesMapper(input);
 Node v8 and v9 compatibly was drop after upgrade `ExcelJS` to version 4+ and it is able to turn on by downgrading `xlsx-import` to version 2.2.1 or if needed really important by requesting me directly.
 
 ## Supported browsers
+
 Chrome, Firefox. [_proved here_](https://github.com/Siemienik/xlsx-import/pull/57)
 
 ## See also


### PR DESCRIPTION
finally closes #61

As forks require to turn on `Actions` to enable auto markdown formatting, I don't believe that everyone will remember/know about that. So I've added check into test workflow that protect agains unformatted merge.