### PR TITLE
Suppress external (codecov) errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,10 @@ jobs:
       run: npm run lint
     - name: Check build
       run: npm run build
-    - name: Check unit & integration tests
-      run: npm run test
-    - name: Run & publish coverage report
-      run: |
-        npm run coverageReport
-        bash <(curl -s https://codecov.io/bash)
+    - name: Check unit & integration tests with coverage
+      run: npm run coverageReport
+    - name: Publish coverage report
+      continue-on-error: true
+      run: bash <(curl -s https://codecov.io/bash)
       env:
         CI: true


### PR DESCRIPTION
because it fail our workflow:

`curl -s https://codecov.io/bash`

```html
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
zzz